### PR TITLE
fix(android): correct OCR overlay scaling, font size, and spurious boxes

### DIFF
--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/services/OcrService.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/services/OcrService.kt
@@ -48,6 +48,10 @@ object OcrService {
                     )
                 }
             }
+            // Drop spurious giant detections (see LiveOcrAnalyzer).
+            .filter { b ->
+                b.height < bitmap.height * 0.5f && b.width < bitmap.width * 0.9f
+            }
 
     }
 
@@ -103,7 +107,21 @@ class LiveOcrAnalyzer(
                             )
                         }
                     }
-                onResult(boxes, image.width, image.height)
+                // ML Kit returns bounding boxes in the upright/display
+                // coordinate space (rotation already applied), but
+                // image.width/height are the unrotated buffer dims. Swap
+                // for 90/270 so the overlay scales against the same space
+                // the boxes are in.
+                val rotated = rotationDegrees == 90 || rotationDegrees == 270
+                val uprightWidth = if (rotated) image.height else image.width
+                val uprightHeight = if (rotated) image.width else image.height
+                // Drop spurious detections: a real text element never spans
+                // half the frame height (or nearly its full width). These
+                // garbage boxes are what render as random HUGE text.
+                val sane = boxes.filter { b ->
+                    b.height < uprightHeight * 0.5f && b.width < uprightWidth * 0.9f
+                }
+                onResult(sane, uprightWidth, uprightHeight)
             }
             .addOnFailureListener { /* ignore for now */ }
             .addOnCompleteListener { imageProxy.close() }

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/screens/camera/Ocr.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/screens/camera/Ocr.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.sp
 import dev.veeso.biangbianghanzi.services.OcrBox
 import kotlinx.coroutines.delay
 import kotlin.math.max
+import kotlin.math.min
 
 @Composable
 fun OcrOverlay(
@@ -84,38 +85,31 @@ fun OcrOverlay(
             }
     ) {
         Canvas(modifier = Modifier.fillMaxSize()) {
-            // Scale factors to match actual image vs displayed size
-            val scaleX = size.width / imageWidth
-            val scaleY = size.height / imageHeight
-
-            val imageAspect = imageWidth.toFloat() / imageHeight
-            val viewAspect = size.width / size.height
-            var verticalOffset: Float = 0f
-            var horizontalOffset: Float = 0f
-
-            if (isLive) {
-                if (imageAspect > viewAspect) {
-                    val scaledHeight = size.width / imageAspect
-                    verticalOffset = (size.height - scaledHeight) / 4f
-                    horizontalOffset = 0f
-                } else {
-                    val scaledWidth = size.height * imageAspect
-                    horizontalOffset = (size.width - scaledWidth) / 2f
-                    verticalOffset = 0f
-                }
+            // Map ML Kit image-pixel coords to view coords using the SAME
+            // transform the preview uses, so boxes align with what's on screen:
+            //  - live preview: PreviewView.ScaleType.FILL_CENTER -> aspect-fill
+            //    (uniform scale = max, overflow cropped, centered)
+            //  - captured image: ContentScale.Fit -> aspect-fit
+            //    (uniform scale = min, letterboxed, centered)
+            // A single uniform scale + centered offsets covers both: the offset
+            // is negative when filling (cropped) and positive when fitting.
+            val scale = if (isLive) {
+                max(size.width / imageWidth, size.height / imageHeight)
+            } else {
+                min(size.width / imageWidth, size.height / imageHeight)
             }
+            val offsetX = (size.width - imageWidth * scale) / 2f
+            val offsetY = (size.height - imageHeight * scale) / 2f
 
             boxes.forEach { box ->
                 val textToDisplay = if (showPinyin) box.pinyin else box.hanzi
                 val scaleRatio =
                     if (showPinyin) box.hanzi.length.toFloat() / box.pinyin.length.toFloat() else 1f
                 val scaleFactor = scaleRatio.coerceIn(0.6f, 1.0f)
-                val boxHeightScaled = if (isLive) {
-                    (box.height * scaleY) / imageAspect
-                } else {
-                    box.height * scaleY
-                }
-                val dynamicFontSize = (boxHeightScaled * 0.5f * scaleFactor).sp
+                // Font tracks the on-screen box height, with a 12sp floor
+                // (matches iOS RecognizedTextOverlay.minFontSize).
+                val dynamicFontSize =
+                    (box.height * scale * 0.4f * scaleFactor).coerceAtLeast(12f).sp
 
                 val textLayout = textMeasurer.measure(
                     text = textToDisplay,
@@ -128,10 +122,10 @@ fun OcrOverlay(
                 val measuredWidth = textLayout.size.width.toFloat()
                 val measuredHeight = textLayout.size.height.toFloat()
 
-                val width = max(box.width * scaleX, measuredWidth + 12f)
-                val height = max(box.height * scaleY, measuredHeight + 12f)
-                val left = box.left * scaleX + horizontalOffset
-                val top = box.top * scaleY - verticalOffset
+                val width = max(box.width * scale, measuredWidth + 12f)
+                val height = max(box.height * scale, measuredHeight + 12f)
+                val left = box.left * scale + offsetX
+                val top = box.top * scale + offsetY
 
                 renderedBoxes.add(
                     box to android.graphics.RectF(left, top, left + width, top + height)


### PR DESCRIPTION
## Problem

Android camera OCR overlay had several issues vs the (correct) iOS app:

1. **Wrong position** — boxes drifted left of the real text.
2. **Wrong font size** — overlay text far too big.
3. **Random huge text** — occasional spurious giant detections.

## Root causes

- Overlay used non-uniform `scaleX`/`scaleY` plus a single-axis `/4f` offset hack — boxes stretched and misaligned.
- ML Kit returns bounding boxes in upright/display space (rotation applied), but `image.width`/`image.height` are the **unrotated buffer** dims. In portrait this swapped width/height → horizontal drift and inflated font scale.
- Spurious ML Kit elements with giant bounding boxes rendered as huge text.

## Fix

- Uniform aspect-fill (live, `PreviewView.FILL_CENTER`) / aspect-fit (captured, `ContentScale.Fit`) scaling with centered offsets so boxes align with what's on screen.
- Swap image dims for 90/270 rotation before scaling.
- Font multiplier `0.5 → 0.4` with a 12sp floor (matches iOS `minFontSize`).
- Drop detections `≥50%` frame height or `≥90%` width on both live and captured paths.

## Testing

Manual on device: live camera + gallery image, portrait and landscape. Position, font size, and spurious-huge-text all confirmed fixed by the reporter. Filter thresholds are tunable constants if edge cases appear.