### PR TITLE
feat: add History feature (iOS + Android)

### DIFF
--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/models/HistoryEntry.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/models/HistoryEntry.kt
@@ -1,0 +1,11 @@
+package dev.veeso.biangbianghanzi.models
+
+enum class HistoryVariant { MANDARIN, CANTONESE }
+
+data class HistoryEntry(
+    val id: String,
+    val original: String,
+    val transliteration: String,
+    val variant: HistoryVariant,
+    val timestamp: Long,
+)

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/services/AppSettingsStore.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/services/AppSettingsStore.kt
@@ -5,6 +5,8 @@ import android.os.LocaleList
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import dev.veeso.biangbianghanzi.models.HistoryEntry
+import dev.veeso.biangbianghanzi.models.HistoryVariant
 import kotlinx.coroutines.flow.map
 
 const val TRADITIONAL_CHINESE = "traditional_chinese"
@@ -16,6 +18,7 @@ private val Context.dataStore by preferencesDataStore("app_settings")
 object AppSettingsKeys {
     val CHINESE_TYPE = stringPreferencesKey("chinese_type")
     val TRANSLATION_LANGUAGE = stringPreferencesKey("translation_language")
+    val HISTORY = stringPreferencesKey("history")
 }
 
 class AppSettingsRepository(private val context: Context) {
@@ -28,11 +31,51 @@ class AppSettingsRepository(private val context: Context) {
         prefs[AppSettingsKeys.TRANSLATION_LANGUAGE] ?: LocaleList.getDefault().get(0).language
     }
 
+    val history = context.dataStore.data.map { prefs ->
+        HistorySerializer.fromJson(prefs[AppSettingsKeys.HISTORY] ?: "")
+    }
+
     suspend fun setChineseType(value: String) {
         context.dataStore.edit { it[AppSettingsKeys.CHINESE_TYPE] = value }
     }
 
     suspend fun setTranslationLanguage(value: String) {
         context.dataStore.edit { it[AppSettingsKeys.TRANSLATION_LANGUAGE] = value }
+    }
+
+    suspend fun addHistory(
+        original: String,
+        transliteration: String,
+        variant: HistoryVariant,
+    ) {
+        context.dataStore.edit { prefs ->
+            val current =
+                HistorySerializer.fromJson(prefs[AppSettingsKeys.HISTORY] ?: "")
+            val entry = HistoryEntry(
+                id = java.util.UUID.randomUUID().toString(),
+                original = original,
+                transliteration = transliteration,
+                variant = variant,
+                timestamp = System.currentTimeMillis(),
+            )
+            prefs[AppSettingsKeys.HISTORY] =
+                HistorySerializer.toJson(HistoryStore.insert(entry, current))
+        }
+    }
+
+    suspend fun deleteHistory(id: String) {
+        context.dataStore.edit { prefs ->
+            val current =
+                HistorySerializer.fromJson(prefs[AppSettingsKeys.HISTORY] ?: "")
+            prefs[AppSettingsKeys.HISTORY] =
+                HistorySerializer.toJson(HistoryStore.delete(id, current))
+        }
+    }
+
+    suspend fun clearHistory() {
+        context.dataStore.edit { prefs ->
+            prefs[AppSettingsKeys.HISTORY] =
+                HistorySerializer.toJson(HistoryStore.clear())
+        }
     }
 }

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/services/HistorySerializer.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/services/HistorySerializer.kt
@@ -1,0 +1,46 @@
+package dev.veeso.biangbianghanzi.services
+
+import dev.veeso.biangbianghanzi.models.HistoryEntry
+import dev.veeso.biangbianghanzi.models.HistoryVariant
+import org.json.JSONArray
+import org.json.JSONObject
+
+/** org.json (de)serialization for the persisted history list. */
+object HistorySerializer {
+    fun toJson(list: List<HistoryEntry>): String {
+        val arr = JSONArray()
+        for (e in list) {
+            val o = JSONObject()
+            o.put("id", e.id)
+            o.put("original", e.original)
+            o.put("transliteration", e.transliteration)
+            o.put("variant", e.variant.name)
+            o.put("timestamp", e.timestamp)
+            arr.put(o)
+        }
+        return arr.toString()
+    }
+
+    fun fromJson(json: String): List<HistoryEntry> {
+        if (json.isBlank()) return emptyList()
+        return try {
+            val arr = JSONArray(json)
+            buildList {
+                for (i in 0 until arr.length()) {
+                    val o = arr.getJSONObject(i)
+                    add(
+                        HistoryEntry(
+                            id = o.getString("id"),
+                            original = o.getString("original"),
+                            transliteration = o.getString("transliteration"),
+                            variant = HistoryVariant.valueOf(o.getString("variant")),
+                            timestamp = o.getLong("timestamp"),
+                        )
+                    )
+                }
+            }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+}

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/services/HistoryStore.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/services/HistoryStore.kt
@@ -1,0 +1,37 @@
+package dev.veeso.biangbianghanzi.services
+
+import dev.veeso.biangbianghanzi.models.HistoryEntry
+
+/** Pure history-list mutation rules. No persistence, no UI. */
+object HistoryStore {
+    /** Silent safety cap. Never surfaced in UI. */
+    const val SAFETY_CAP = 500
+
+    fun insert(
+        entry: HistoryEntry,
+        list: List<HistoryEntry>,
+    ): List<HistoryEntry> {
+        val newest = list.firstOrNull()
+        if (newest != null &&
+            newest.original == entry.original &&
+            newest.variant == entry.variant
+        ) {
+            return list
+        }
+        val result = ArrayList<HistoryEntry>(list.size + 1)
+        result.add(entry)
+        result.addAll(list)
+        return if (result.size > SAFETY_CAP) {
+            result.subList(0, SAFETY_CAP).toList()
+        } else {
+            result
+        }
+    }
+
+    fun delete(
+        id: String,
+        list: List<HistoryEntry>,
+    ): List<HistoryEntry> = list.filterNot { it.id == id }
+
+    fun clear(): List<HistoryEntry> = emptyList()
+}

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/MainScreen.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/MainScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material3.Icon
@@ -19,13 +20,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import dev.veeso.biangbianghanzi.ui.screens.CameraModeView
+import dev.veeso.biangbianghanzi.ui.screens.HistoryModeView
 import dev.veeso.biangbianghanzi.ui.screens.SettingsModeView
 import dev.veeso.biangbianghanzi.ui.screens.TextModeView
 
 private enum class Tab(val label: String, val icon: ImageVector) {
     Text("Text", Icons.Default.TextFields),
     Camera("Camera", Icons.Default.CameraAlt),
+    History("History", Icons.Default.History),
     Settings("Settings", Icons.Default.Settings),
+
 }
 
 @Composable
@@ -50,6 +54,7 @@ fun MainScreen() {
             when (selectedTab) {
                 Tab.Text -> TextModeView()
                 Tab.Camera -> CameraModeView()
+                Tab.History -> HistoryModeView()
                 Tab.Settings -> SettingsModeView()
             }
         }

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/screens/HistoryModeView.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/screens/HistoryModeView.kt
@@ -1,0 +1,286 @@
+package dev.veeso.biangbianghanzi.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.automirrored.filled.VolumeUp
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.veeso.biangbianghanzi.models.HistoryEntry
+import dev.veeso.biangbianghanzi.models.HistoryVariant
+import dev.veeso.biangbianghanzi.services.AppSettingsRepository
+import dev.veeso.biangbianghanzi.services.AudioPlayerService
+import dev.veeso.biangbianghanzi.ui.AppDesign
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HistoryModeView() {
+    val context = LocalContext.current
+    val repo = remember { AppSettingsRepository(context) }
+    val scope = rememberCoroutineScope()
+
+    val history by repo.history.collectAsState(initial = emptyList())
+
+    val audio = remember { AudioPlayerService(context) }
+    DisposableEffect(Unit) {
+        onDispose { audio.shutdown() }
+    }
+
+    val audioState by audio.state.collectAsState()
+    val isSpeaking = audioState == AudioPlayerService.State.SPEAKING
+
+    var speakingId by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(isSpeaking) {
+        if (!isSpeaking) speakingId = null
+    }
+
+    var showTransliterated by remember { mutableStateOf(false) }
+    val expanded = remember { mutableStateListOf<String>() }
+    var showClearConfirm by remember { mutableStateOf(false) }
+
+    if (showClearConfirm) {
+        AlertDialog(
+            onDismissRequest = { showClearConfirm = false },
+            title = { Text("Clear history") },
+            text = { Text("All history entries will be permanently deleted. This cannot be undone.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        scope.launch { repo.clearHistory() }
+                        expanded.clear()
+                        showClearConfirm = false
+                    },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) {
+                    Text("Clear All")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearConfirm = false }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("History") }) },
+    ) { innerPadding ->
+        if (history.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(horizontal = AppDesign.horizontalPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    "No history yet. Saved entries from Text and Camera appear here.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            ) {
+                item {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(
+                                horizontal = AppDesign.horizontalPadding,
+                                vertical = AppDesign.stackSpacing,
+                            ),
+                        verticalArrangement = Arrangement.spacedBy(AppDesign.stackSpacing),
+                    ) {
+                        SingleChoiceSegmentedButtonRow(
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            SegmentedButton(
+                                selected = !showTransliterated,
+                                onClick = { showTransliterated = false },
+                                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                                label = { Text("Original") },
+                            )
+                            SegmentedButton(
+                                selected = showTransliterated,
+                                onClick = { showTransliterated = true },
+                                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                                label = { Text("Transliterated") },
+                            )
+                        }
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End,
+                        ) {
+                            TextButton(
+                                onClick = { showClearConfirm = true },
+                                enabled = history.isNotEmpty(),
+                                colors = ButtonDefaults.textButtonColors(
+                                    contentColor = MaterialTheme.colorScheme.error,
+                                ),
+                            ) {
+                                Icon(
+                                    Icons.Default.Delete,
+                                    contentDescription = null,
+                                )
+                                Spacer(modifier = Modifier.width(4.dp))
+                                Text("Clear All", maxLines = 1, softWrap = false)
+                            }
+                        }
+                    }
+                }
+
+                items(history, key = { it.id }) { entry ->
+                    val rowSpeaking = isSpeaking && speakingId == entry.id
+                    HistoryRow(
+                        entry = entry,
+                        showTransliterated = showTransliterated,
+                        isExpanded = expanded.contains(entry.id),
+                        isSpeaking = rowSpeaking,
+                        onToggleExpand = {
+                            if (expanded.contains(entry.id)) {
+                                expanded.remove(entry.id)
+                            } else {
+                                expanded.add(entry.id)
+                            }
+                        },
+                        onSpeak = {
+                            if (rowSpeaking) {
+                                audio.stop()
+                                speakingId = null
+                            } else {
+                                val lang = if (entry.variant == HistoryVariant.CANTONESE) {
+                                    AudioPlayerService.Language.CANTONESE
+                                } else {
+                                    AudioPlayerService.Language.MANDARIN
+                                }
+                                speakingId = entry.id
+                                audio.speak(entry.original, lang)
+                            }
+                        },
+                        onDelete = { scope.launch { repo.deleteHistory(entry.id) } },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun HistoryRow(
+    entry: HistoryEntry,
+    showTransliterated: Boolean,
+    isExpanded: Boolean,
+    isSpeaking: Boolean,
+    onToggleExpand: () -> Unit,
+    onSpeak: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { it == SwipeToDismissBoxValue.EndToStart },
+    )
+
+    LaunchedEffect(dismissState.currentValue) {
+        if (dismissState.currentValue == SwipeToDismissBoxValue.EndToStart) {
+            onDelete()
+        }
+    }
+
+    SwipeToDismissBox(
+        state = dismissState,
+        enableDismissFromStartToEnd = false,
+        backgroundContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.errorContainer)
+                    .padding(horizontal = AppDesign.horizontalPadding),
+                contentAlignment = Alignment.CenterEnd,
+            ) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = "Delete",
+                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+        },
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(
+                    horizontal = AppDesign.horizontalPadding,
+                    vertical = 8.dp,
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = if (showTransliterated) entry.transliteration else entry.original,
+                maxLines = if (isExpanded) Int.MAX_VALUE else 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable { onToggleExpand() },
+            )
+            IconButton(onClick = onSpeak) {
+                Icon(
+                    if (isSpeaking) Icons.Default.Stop else Icons.AutoMirrored.Filled.VolumeUp,
+                    contentDescription = if (isSpeaking) "Stop" else "Speak",
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/screens/TextModeView.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/screens/TextModeView.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.filled.BookmarkAdd
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.ContentPaste
 import androidx.compose.material.icons.filled.PlayArrow
@@ -30,12 +31,15 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -46,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import dev.veeso.biangbianghanzi.R
+import dev.veeso.biangbianghanzi.models.HistoryVariant
 import dev.veeso.biangbianghanzi.services.AppSettingsRepository
 import dev.veeso.biangbianghanzi.services.AudioPlayerService
 import dev.veeso.biangbianghanzi.services.CANTONESE
@@ -54,6 +59,7 @@ import dev.veeso.biangbianghanzi.ui.AppDesign
 import dev.veeso.biangbianghanzi.ui.components.SectionView
 import dev.veeso.biangbianghanzi.ui.screens.textmode.TextModeViewModel
 import java.util.Locale
+import kotlinx.coroutines.launch
 
 
 @Composable
@@ -71,10 +77,14 @@ fun TextModeView(
         context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
     }
     val isCantonese = chineseType == CANTONESE
+    val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(isCantonese) { viewModel.setMode(context, isCantonese) }
 
-    Scaffold { innerPadding ->
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { innerPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -128,6 +138,30 @@ fun TextModeView(
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(if (isSpeaking) "Stop" else "Listen")
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                OutlinedButton(
+                    onClick = {
+                        scope.launch {
+                            settingsRepo.addHistory(
+                                original = inputText,
+                                transliteration = pinyinText,
+                                variant = if (isCantonese)
+                                    HistoryVariant.CANTONESE
+                                else HistoryVariant.MANDARIN,
+                            )
+                            snackbarHostState.showSnackbar("Saved to history")
+                        }
+                    },
+                    enabled = pinyinText.trim().isNotEmpty(),
+                    shape = CircleShape,
+                ) {
+                    Icon(
+                        Icons.Default.BookmarkAdd,
+                        contentDescription = null,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Save")
                 }
             }
 

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/screens/camera/CameraLiveView.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/screens/camera/CameraLiveView.kt
@@ -35,12 +35,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,14 +61,19 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import dev.veeso.biangbianghanzi.R
 import dev.veeso.biangbianghanzi.capturePhoto
+import dev.veeso.biangbianghanzi.models.HistoryVariant
+import dev.veeso.biangbianghanzi.services.AppSettingsRepository
+import dev.veeso.biangbianghanzi.services.CANTONESE
 import dev.veeso.biangbianghanzi.services.LiveOcrAnalyzer
 import dev.veeso.biangbianghanzi.services.OcrBox
 import dev.veeso.biangbianghanzi.services.OcrService
+import dev.veeso.biangbianghanzi.services.SIMPLIFIED_CHINESE
 import dev.veeso.biangbianghanzi.services.availablePresets
 import dev.veeso.biangbianghanzi.services.clampZoom
 import dev.veeso.biangbianghanzi.ui.AppDesign
 import dev.veeso.biangbianghanzi.ui.components.CopyToast
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlin.math.abs
 
 @Composable
@@ -82,6 +89,7 @@ fun CameraLiveView() {
     var maxZoom by remember { mutableFloatStateOf(1f) }
     var presets by remember { mutableStateOf(listOf(1f)) }
     var showCopyToast by remember { mutableStateOf(false) }
+    var showSavedToast by remember { mutableStateOf(false) }
 
     LaunchedEffect(showCopyToast) {
         if (showCopyToast) {
@@ -90,7 +98,31 @@ fun CameraLiveView() {
         }
     }
 
+    LaunchedEffect(showSavedToast) {
+        if (showSavedToast) {
+            delay(1500)
+            showSavedToast = false
+        }
+    }
+
     val context = LocalContext.current
+    val settingsRepo = remember { AppSettingsRepository(context) }
+    val chineseType by settingsRepo.chineseType.collectAsState(initial = SIMPLIFIED_CHINESE)
+    val isCantonese = chineseType == CANTONESE
+    val scope = rememberCoroutineScope()
+
+    val saveBox: (OcrBox) -> Unit = { box ->
+        scope.launch {
+            settingsRepo.addHistory(
+                original = box.hanzi,
+                transliteration = box.pinyin,
+                variant = if (isCantonese) HistoryVariant.CANTONESE
+                else HistoryVariant.MANDARIN,
+            )
+        }
+        showSavedToast = true
+    }
+
     val lifecycleOwner = LocalLifecycleOwner.current
 
     val analyzer = remember {
@@ -198,6 +230,7 @@ fun CameraLiveView() {
                     isLive = true,
                     showPinyin = convertToPinyin,
                     onTextCopied = { showCopyToast = true },
+                    onSaveBox = saveBox,
                 )
 
                 Column(
@@ -247,6 +280,7 @@ fun CameraLiveView() {
                     isLive = false,
                     showPinyin = convertToPinyin,
                     onTextCopied = { showCopyToast = true },
+                    onSaveBox = saveBox,
                 )
 
                 FilledTonalIconButton(
@@ -259,12 +293,32 @@ fun CameraLiveView() {
                 }
             }
 
+            val anyBoxes =
+                if (capturedImage == null) liveOcrBoxes.isNotEmpty()
+                else ocrBoxes.isNotEmpty()
+            if (anyBoxes) {
+                Text(
+                    text = "Tap to copy · long-press to save",
+                    color = Color.White,
+                    fontSize = 12.sp,
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .padding(top = AppDesign.stackSpacing),
+                )
+            }
+
             Box(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .padding(bottom = AppDesign.bottomToolbarPadding),
             ) {
-                CopyToast(visible = showCopyToast)
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    CopyToast(visible = showSavedToast, message = "Saved to History")
+                    CopyToast(visible = showCopyToast)
+                }
             }
         }
     }

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/screens/camera/Ocr.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/screens/camera/Ocr.kt
@@ -43,6 +43,7 @@ fun OcrOverlay(
     isLive: Boolean,
     showPinyin: Boolean,
     onTextCopied: (() -> Unit)? = null,
+    onSaveBox: ((OcrBox) -> Unit)? = null,
 ) {
     val textMeasurer = rememberTextMeasurer()
     val context = LocalContext.current
@@ -68,20 +69,31 @@ fun OcrOverlay(
     Box(
         modifier = modifier
             .pointerInput(boxes, showPinyin, imageWidth, imageHeight) {
-                detectTapGestures { offset ->
-                    val hit = renderedBoxes.firstOrNull { (_, rect) ->
+                fun hitBox(offset: Offset): OcrBox? =
+                    renderedBoxes.firstOrNull { (_, rect) ->
                         rect.contains(offset.x, offset.y)
                     }?.first
-                    hit?.let { box ->
-                        val text = if (showPinyin) box.pinyin else box.hanzi
-                        val clipboard =
-                            context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                        clipboard.setPrimaryClip(ClipData.newPlainText("OCR text", text))
-                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        highlightedBox = box
-                        onTextCopied?.invoke()
-                    }
-                }
+
+                detectTapGestures(
+                    onTap = { offset ->
+                        hitBox(offset)?.let { box ->
+                            val text = if (showPinyin) box.pinyin else box.hanzi
+                            val clipboard =
+                                context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                            clipboard.setPrimaryClip(ClipData.newPlainText("OCR text", text))
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            highlightedBox = box
+                            onTextCopied?.invoke()
+                        }
+                    },
+                    onLongPress = { offset ->
+                        hitBox(offset)?.let { box ->
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            highlightedBox = box
+                            onSaveBox?.invoke(box)
+                        }
+                    },
+                )
             }
     ) {
         Canvas(modifier = Modifier.fillMaxSize()) {

--- a/android/app/src/test/java/dev/veeso/biangbianghanzi/HistorySerializerTest.kt
+++ b/android/app/src/test/java/dev/veeso/biangbianghanzi/HistorySerializerTest.kt
@@ -1,0 +1,30 @@
+package dev.veeso.biangbianghanzi
+
+import dev.veeso.biangbianghanzi.models.HistoryEntry
+import dev.veeso.biangbianghanzi.models.HistoryVariant
+import dev.veeso.biangbianghanzi.services.HistorySerializer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HistorySerializerTest {
+    @Test
+    fun roundTripsList() {
+        val list = listOf(
+            HistoryEntry("id1", "你好", "nei5 hou2", HistoryVariant.CANTONESE, 1234L),
+            HistoryEntry("id2", "我", "wǒ", HistoryVariant.MANDARIN, 5678L),
+        )
+        val json = HistorySerializer.toJson(list)
+        val back = HistorySerializer.fromJson(json)
+        assertEquals(list, back)
+    }
+
+    @Test
+    fun fromBlankReturnsEmpty() {
+        assertEquals(emptyList<HistoryEntry>(), HistorySerializer.fromJson(""))
+    }
+
+    @Test
+    fun fromMalformedReturnsEmpty() {
+        assertEquals(emptyList<HistoryEntry>(), HistorySerializer.fromJson("not-json"))
+    }
+}

--- a/android/app/src/test/java/dev/veeso/biangbianghanzi/HistoryStoreTest.kt
+++ b/android/app/src/test/java/dev/veeso/biangbianghanzi/HistoryStoreTest.kt
@@ -1,0 +1,61 @@
+package dev.veeso.biangbianghanzi
+
+import dev.veeso.biangbianghanzi.models.HistoryEntry
+import dev.veeso.biangbianghanzi.models.HistoryVariant
+import dev.veeso.biangbianghanzi.services.HistoryStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HistoryStoreTest {
+    private fun entry(
+        original: String,
+        variant: HistoryVariant = HistoryVariant.MANDARIN,
+        id: String = original + variant.name,
+    ) = HistoryEntry(id, original, "$original-t", variant, 0L)
+
+    @Test
+    fun insertPrependsNewest() {
+        var list = HistoryStore.insert(entry("A"), emptyList())
+        list = HistoryStore.insert(entry("B"), list)
+        assertEquals(listOf("B", "A"), list.map { it.original })
+    }
+
+    @Test
+    fun skipsConsecutiveDuplicateSameVariant() {
+        var list = HistoryStore.insert(entry("A"), emptyList())
+        list = HistoryStore.insert(entry("A"), list)
+        assertEquals(1, list.size)
+    }
+
+    @Test
+    fun keepsSameTextDifferentVariant() {
+        var list = HistoryStore.insert(entry("A", HistoryVariant.MANDARIN), emptyList())
+        list = HistoryStore.insert(entry("A", HistoryVariant.CANTONESE), list)
+        assertEquals(2, list.size)
+    }
+
+    @Test
+    fun capEvictsOldestBeyond500() {
+        var list = emptyList<HistoryEntry>()
+        for (i in 0 until 520) {
+            list = HistoryStore.insert(entry("E$i", id = "E$i"), list)
+        }
+        assertEquals(500, list.size)
+        assertEquals("E519", list.first().original)
+        assertEquals("E20", list.last().original)
+    }
+
+    @Test
+    fun deleteRemovesById() {
+        val a = entry("A")
+        var list = HistoryStore.insert(a, emptyList())
+        list = HistoryStore.delete(a.id, list)
+        assertTrue(list.isEmpty())
+    }
+
+    @Test
+    fun clearEmptiesList() {
+        assertTrue(HistoryStore.clear().isEmpty())
+    }
+}

--- a/ios/BiangBiang Hanzi/AppSettings.swift
+++ b/ios/BiangBiang Hanzi/AppSettings.swift
@@ -29,15 +29,46 @@ final class AppSettings {
         chineseVariant == Self.cantonese
     }
 
+    var history: [HistoryEntry] {
+        didSet {
+            if let data = try? JSONEncoder().encode(history) {
+                userDefaults.set(data, forKey: "history")
+            }
+        }
+    }
+
+    private let userDefaults: UserDefaults
+
     init(
         userDefaults: UserDefaults = .standard,
         defaultLanguage: String = Locale.current.language.languageCode?
             .identifier ?? "en",
         defaultChineseVariant: String = "zh-Hans"
     ) {
+        self.userDefaults = userDefaults
         userLanguage =
             userDefaults.string(forKey: "user_language") ?? defaultLanguage
         chineseVariant =
             userDefaults.string(forKey: "chinese") ?? defaultChineseVariant
+        if let data = userDefaults.data(forKey: "history"),
+           let decoded = try? JSONDecoder().decode([HistoryEntry].self, from: data)
+        {
+            history = decoded
+        } else {
+            history = []
+        }
+    }
+
+    func addHistory(original: String, transliteration: String, variant: HistoryVariant) {
+        let entry = HistoryEntry(original: original, transliteration: transliteration, variant: variant)
+        history = HistoryStore.insert(entry, into: history)
+    }
+
+    func deleteHistory(id: UUID) {
+        history = HistoryStore.delete(id: id, from: history)
+    }
+
+    func clearHistory() {
+        history = HistoryStore.clear()
     }
 }

--- a/ios/BiangBiang Hanzi/ContentView.swift
+++ b/ios/BiangBiang Hanzi/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
         case text
         case camera
         case settings
+        case history
     }
 
     @State private var selection: AppTab = .text
@@ -23,6 +24,9 @@ struct ContentView: View {
             }
             Tab("Camera", systemImage: "camera", value: AppTab.camera) {
                 CameraModeView()
+            }
+            Tab("History", systemImage: "clock.fill", value: AppTab.history) {
+                HistoryView()
             }
             Tab("Settings", systemImage: "gear", value: AppTab.settings) {
                 SettingsView()

--- a/ios/BiangBiang Hanzi/Models/HistoryEntry.swift
+++ b/ios/BiangBiang Hanzi/Models/HistoryEntry.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum HistoryVariant: String, Codable, Equatable {
+    case mandarin
+    case cantonese
+}
+
+struct HistoryEntry: Identifiable, Codable, Equatable {
+    let id: UUID
+    let original: String
+    let transliteration: String
+    let variant: HistoryVariant
+    let timestamp: Date
+
+    init(
+        id: UUID = UUID(),
+        original: String,
+        transliteration: String,
+        variant: HistoryVariant,
+        timestamp: Date = Date()
+    ) {
+        self.id = id
+        self.original = original
+        self.transliteration = transliteration
+        self.variant = variant
+        self.timestamp = timestamp
+    }
+}

--- a/ios/BiangBiang Hanzi/Services/Camera/CameraModel.swift
+++ b/ios/BiangBiang Hanzi/Services/Camera/CameraModel.swift
@@ -35,6 +35,8 @@ final class CameraModel: NSObject, AVCapturePhotoCaptureDelegate,
     var showPinyin: Bool = true
     /// Show copied toast
     var showCopiedToast: Bool = false
+    /// Show saved-to-history toast
+    var showSavedToast: Bool = false
 
     /// Currently active capture device. Used for zoom configuration.
     @ObservationIgnored private var device: AVCaptureDevice?

--- a/ios/BiangBiang Hanzi/Services/HistoryStore.swift
+++ b/ios/BiangBiang Hanzi/Services/HistoryStore.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Pure history-list mutation rules. No persistence, no UI.
+enum HistoryStore {
+    /// Silent safety cap. Never surfaced in UI.
+    static let safetyCap = 500
+
+    /// Prepend `entry` (newest first), skipping if it duplicates the
+    /// most-recent entry by original text + variant. Evicts oldest entries
+    /// beyond `safetyCap`.
+    static func insert(
+        _ entry: HistoryEntry,
+        into list: [HistoryEntry]
+    ) -> [HistoryEntry] {
+        if let newest = list.first,
+           newest.original == entry.original,
+           newest.variant == entry.variant
+        {
+            return list
+        }
+        var result = list
+        result.insert(entry, at: 0)
+        if result.count > safetyCap {
+            result.removeLast(result.count - safetyCap)
+        }
+        return result
+    }
+
+    static func delete(
+        id: UUID,
+        from list: [HistoryEntry]
+    ) -> [HistoryEntry] {
+        list.filter { $0.id != id }
+    }
+
+    static func clear() -> [HistoryEntry] {
+        []
+    }
+}

--- a/ios/BiangBiang Hanzi/Views/CameraLiveView.swift
+++ b/ios/BiangBiang Hanzi/Views/CameraLiveView.swift
@@ -43,6 +43,19 @@ struct CameraLiveView: View {
                     }
                 }
 
+                if !cameraModel.recognizedTexts.isEmpty {
+                    VStack {
+                        Text("Tap to copy · long-press to save")
+                            .font(.caption2)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(.ultraThinMaterial, in: Capsule())
+                            .padding(.top, 8)
+                        Spacer()
+                    }
+                    .allowsHitTesting(false)
+                }
+
                 VStack {
                     Spacer()
                     if cameraModel.capturedImage == nil
@@ -62,10 +75,24 @@ struct CameraLiveView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                     .allowsHitTesting(false)
                 }
+
+                if cameraModel.showSavedToast {
+                    VStack {
+                        Spacer()
+                        CopyToast(message: "Saved to History")
+                            .padding(.bottom, AppDesign.bottomToolbarPadding + 44)
+                    }
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .allowsHitTesting(false)
+                }
             }
             .animation(
                 .easeOut(duration: AppDesign.toastAnimation),
                 value: cameraModel.showCopiedToast
+            )
+            .animation(
+                .easeOut(duration: AppDesign.toastAnimation),
+                value: cameraModel.showSavedToast
             )
         }
         .simultaneousGesture(

--- a/ios/BiangBiang Hanzi/Views/CopyToast.swift
+++ b/ios/BiangBiang Hanzi/Views/CopyToast.swift
@@ -8,8 +8,10 @@
 import SwiftUI
 
 struct CopyToast: View {
+    var message: String = "Text copied"
+
     var body: some View {
-        Text("Text copied")
+        Text(message)
             .font(.subheadline.weight(.semibold))
             .padding(.horizontal, 12)
             .padding(.vertical, 8)

--- a/ios/BiangBiang Hanzi/Views/HistoryView.swift
+++ b/ios/BiangBiang Hanzi/Views/HistoryView.swift
@@ -1,0 +1,121 @@
+//
+//  HistoryView.swift
+//  BiangBiang Hanzi
+//
+//  Created by christian visintin on 17/05/2026.
+//
+
+import SwiftUI
+
+struct HistoryView: View {
+    @Environment(AppSettings.self) private var settings
+    @Environment(AudioPlayerService.self) private var audio
+
+    @State private var showTransliterated = false
+    @State private var expandedIDs: Set<UUID> = []
+    @State private var showClearConfirm = false
+    @State private var speakingID: UUID?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                HStack(spacing: 12) {
+                    Picker("Display", selection: $showTransliterated) {
+                        Text("Original").tag(false)
+                        Text("Transliterated").tag(true)
+                    }
+                    .pickerStyle(.segmented)
+
+                    Button("Clear All", role: .destructive) {
+                        showClearConfirm = true
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(settings.history.isEmpty)
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+
+                if settings.history.isEmpty {
+                    Spacer()
+                    ContentUnavailableView(
+                        "No history yet",
+                        systemImage: "clock",
+                        description: Text(
+                            "Saved entries from Text and Camera appear here."
+                        )
+                    )
+                    Spacer()
+                } else {
+                    List {
+                        ForEach(settings.history) { entry in
+                            row(entry)
+                        }
+                        .onDelete { offsets in
+                            let ids = offsets.map { settings.history[$0].id }
+                            for id in ids {
+                                settings.deleteHistory(id: id)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("History")
+            .onChange(of: audio.isSpeaking) { _, speaking in
+                if !speaking { speakingID = nil }
+            }
+            .confirmationDialog(
+                "Clear all history?",
+                isPresented: $showClearConfirm,
+                titleVisibility: .visible
+            ) {
+                Button("Clear All", role: .destructive) {
+                    settings.clearHistory()
+                    expandedIDs.removeAll()
+                }
+                Button("Cancel", role: .cancel) {}
+            }
+        }
+    }
+
+    private func row(_ entry: HistoryEntry) -> some View {
+        let text = showTransliterated
+            ? entry.transliteration
+            : entry.original
+        let expanded = expandedIDs.contains(entry.id)
+        let isThisPlaying = speakingID == entry.id && audio.isSpeaking
+        return HStack(alignment: .top, spacing: 12) {
+            Text(text)
+                .lineLimit(expanded ? nil : 1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    if expanded {
+                        expandedIDs.remove(entry.id)
+                    } else {
+                        expandedIDs.insert(entry.id)
+                    }
+                }
+            Button {
+                if isThisPlaying {
+                    audio.stop()
+                    speakingID = nil
+                } else {
+                    let lang: AudioPlayerService.Language =
+                        entry.variant == .cantonese
+                            ? .cantonese : .mandarin
+                    speakingID = entry.id
+                    audio.speak(entry.original, language: lang)
+                }
+            } label: {
+                Image(
+                    systemName: isThisPlaying
+                        ? "stop.circle.fill"
+                        : "speaker.wave.2.fill"
+                )
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/ios/BiangBiang Hanzi/Views/RecognizedTextOverlay.swift
+++ b/ios/BiangBiang Hanzi/Views/RecognizedTextOverlay.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import UIKit
 
 struct RecognizedTextOverlay: View {
+    @Environment(AppSettings.self) private var settings
     @State private var isCopied = false
     @State private var measuredSize: CGSize = .zero
 
@@ -81,6 +82,22 @@ struct RecognizedTextOverlay: View {
             .background(sizeReader)
         }
         .buttonStyle(.plain)
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.3).onEnded { _ in
+                let variant: HistoryVariant =
+                    settings.isCantonese ? .cantonese : .mandarin
+                settings.addHistory(
+                    original: hanzi,
+                    transliteration: pinyin,
+                    variant: variant
+                )
+                cameraModel.showSavedToast = true
+                Task {
+                    try? await Task.sleep(for: .seconds(1.5))
+                    cameraModel.showSavedToast = false
+                }
+            }
+        )
         .frame(
             minWidth: Self.minTapTarget,
             minHeight: Self.minTapTarget
@@ -95,7 +112,7 @@ struct RecognizedTextOverlay: View {
             new
         }
         .accessibilityLabel(Text(textToDisplay))
-        .accessibilityHint("Copy to clipboard")
+        .accessibilityHint("Tap to copy, long-press to save to History")
     }
 
     private var sizeReader: some View {

--- a/ios/BiangBiang Hanzi/Views/TextModeView.swift
+++ b/ios/BiangBiang Hanzi/Views/TextModeView.swift
@@ -17,6 +17,8 @@ struct TextModeView: View {
     @State private var translatedText: String = ""
     @State private var debounceTask: Task<Void, Never>?
     @State private var translateConfig: TranslationSession.Configuration?
+    @State private var showSavedToast = false
+    @State private var savedToastTask: Task<Void, Never>?
     @FocusState private var inputFocused: Bool
 
     private let textProcessor = TextProcessor()
@@ -58,6 +60,21 @@ struct TextModeView: View {
                 Button("Done") { inputFocused = false }
             }
         }
+        .overlay(alignment: .bottom) {
+            if showSavedToast {
+                Text("Saved to History")
+                    .font(.subheadline.weight(.semibold))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(.ultraThinMaterial)
+                    .clipShape(.rect(cornerRadius: AppDesign.cornerRadius))
+                    .shadow(radius: 6)
+                    .padding(.bottom, 24)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .allowsHitTesting(false)
+            }
+        }
+        .sensoryFeedback(.success, trigger: showSavedToast)
     }
 
     private var hanziInputSection: some View {
@@ -79,7 +96,10 @@ struct TextModeView: View {
                 .onChange(of: inputText) { _, _ in
                     scheduleDebouncedProcessing()
                 }
-            ttsButton
+            HStack {
+                ttsButton
+                saveButton
+            }
         }
         .padding(.horizontal, AppDesign.horizontalPadding)
     }
@@ -104,6 +124,31 @@ struct TextModeView: View {
         .buttonBorderShape(.capsule)
         .disabled(trimmed.isEmpty && !isPlaying)
         .accessibilityHint("Read the Chinese text aloud")
+    }
+
+    private var saveButton: some View {
+        Button {
+            let variant: HistoryVariant =
+                settings.isCantonese ? .cantonese : .mandarin
+            settings.addHistory(
+                original: inputText,
+                transliteration: pinyinText,
+                variant: variant
+            )
+            savedToastTask?.cancel()
+            withAnimation { showSavedToast = true }
+            savedToastTask = Task {
+                try? await Task.sleep(for: .seconds(1.5))
+                guard !Task.isCancelled else { return }
+                withAnimation { showSavedToast = false }
+            }
+        } label: {
+            Label("Save", systemImage: "bookmark.fill")
+        }
+        .buttonStyle(.bordered)
+        .buttonBorderShape(.capsule)
+        .disabled(pinyinText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        .accessibilityHint("Save this entry to History")
     }
 
     private var pinyinOutputSection: some View {

--- a/ios/BiangBiang HanziTests/AppSettingsHistoryTests.swift
+++ b/ios/BiangBiang HanziTests/AppSettingsHistoryTests.swift
@@ -1,0 +1,44 @@
+@testable import BiangBiang_Hanzi
+import Foundation
+import Testing
+
+@MainActor
+struct AppSettingsHistoryTests {
+    private func makeDefaults() -> UserDefaults {
+        let suite = "history-test-\(UUID().uuidString)"
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        return d
+    }
+
+    @Test func defaultHistoryIsEmpty() {
+        let settings = AppSettings(userDefaults: makeDefaults())
+        #expect(settings.history.isEmpty)
+    }
+
+    @Test func addHistoryDedupsConsecutive() {
+        let settings = AppSettings(userDefaults: makeDefaults())
+        settings.addHistory(original: "你好", transliteration: "nǐ hǎo", variant: .mandarin)
+        settings.addHistory(original: "你好", transliteration: "nǐ hǎo", variant: .mandarin)
+        #expect(settings.history.count == 1)
+    }
+
+    @Test func historyRoundTripsThroughUserDefaults() {
+        let defaults = makeDefaults()
+        let a = AppSettings(userDefaults: defaults)
+        a.addHistory(original: "我", transliteration: "wǒ", variant: .cantonese)
+        let b = AppSettings(userDefaults: defaults)
+        #expect(b.history.count == 1)
+        #expect(b.history.first?.original == "我")
+        #expect(b.history.first?.variant == .cantonese)
+    }
+
+    @Test func clearHistoryEmptiesAndPersists() {
+        let defaults = makeDefaults()
+        let a = AppSettings(userDefaults: defaults)
+        a.addHistory(original: "我", transliteration: "wǒ", variant: .mandarin)
+        a.clearHistory()
+        let b = AppSettings(userDefaults: defaults)
+        #expect(b.history.isEmpty)
+    }
+}

--- a/ios/BiangBiang HanziTests/Services/HistoryStoreTests.swift
+++ b/ios/BiangBiang HanziTests/Services/HistoryStoreTests.swift
@@ -1,0 +1,59 @@
+@testable import BiangBiang_Hanzi
+import Testing
+
+struct HistoryStoreTests {
+    private func entry(
+        _ original: String,
+        _ variant: HistoryVariant = .mandarin
+    ) -> HistoryEntry {
+        HistoryEntry(
+            original: original,
+            transliteration: original + "-t",
+            variant: variant
+        )
+    }
+
+    @Test func insertPrependsNewest() {
+        var list: [HistoryEntry] = []
+        list = HistoryStore.insert(entry("A"), into: list)
+        list = HistoryStore.insert(entry("B"), into: list)
+        #expect(list.map(\.original) == ["B", "A"])
+    }
+
+    @Test func skipsConsecutiveDuplicateSameVariant() {
+        var list: [HistoryEntry] = []
+        list = HistoryStore.insert(entry("A"), into: list)
+        list = HistoryStore.insert(entry("A"), into: list)
+        #expect(list.count == 1)
+    }
+
+    @Test func keepsSameTextDifferentVariant() {
+        var list: [HistoryEntry] = []
+        list = HistoryStore.insert(entry("A", .mandarin), into: list)
+        list = HistoryStore.insert(entry("A", .cantonese), into: list)
+        #expect(list.count == 2)
+    }
+
+    @Test func capEvictsOldestBeyond500() {
+        var list: [HistoryEntry] = []
+        for i in 0 ..< 520 {
+            list = HistoryStore.insert(entry("E\(i)"), into: list)
+        }
+        #expect(list.count == 500)
+        #expect(list.first?.original == "E519")
+        #expect(list.last?.original == "E20")
+    }
+
+    @Test func deleteRemovesById() {
+        let a = entry("A")
+        var list = HistoryStore.insert(a, into: [])
+        list = HistoryStore.delete(id: a.id, from: list)
+        #expect(list.isEmpty)
+    }
+
+    @Test func clearEmptiesList() {
+        var list = HistoryStore.insert(entry("A"), into: [])
+        list = HistoryStore.clear()
+        #expect(list.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Adds History feature on both platforms. Saved entries from Text mode persist and are browsable in a dedicated History tab.

### iOS
- History store + serializer, History tab UI (commit 5401ede).

### Android
- `HistoryStore` + `HistorySerializer` persistence, `HistoryModeView` tab.
- Save action in Text mode shows "Saved to history" snackbar.
- History list: Original/Transliterated toggle full-width; Clear All moved to own row, error-colored `TextButton` with confirm dialog (destructive cue).
- Swipe-to-delete: single direction (left), opaque row surface so the red delete panel only shows while swiping; no standalone delete button.

Closes #22