### PR TITLE
feat: rate-the-app prompt (iOS + Android)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -34,6 +34,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 
@@ -74,5 +75,6 @@ dependencies {
     implementation(libs.androidx.camera.extensions)
     implementation(libs.kotlinx.coroutines.play.services)
     implementation(libs.text.recognition.chinese)
+    implementation(libs.play.review.ktx)
 
 }

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/MainActivity.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/MainActivity.kt
@@ -4,12 +4,19 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.lifecycle.lifecycleScope
+import dev.veeso.biangbianghanzi.services.AppSettingsRepository
 import dev.veeso.biangbianghanzi.ui.MainScreen
 import dev.veeso.biangbianghanzi.ui.theme.BiangBiangHanziTheme
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (savedInstanceState == null) {
+            val repo = AppSettingsRepository(applicationContext)
+            lifecycleScope.launch { repo.registerLaunch() }
+        }
         enableEdgeToEdge()
         setContent {
             BiangBiangHanziTheme {

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/services/AppSettingsStore.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/services/AppSettingsStore.kt
@@ -2,7 +2,9 @@ package dev.veeso.biangbianghanzi.services
 
 import android.content.Context
 import android.os.LocaleList
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dev.veeso.biangbianghanzi.models.HistoryEntry
@@ -19,6 +21,9 @@ object AppSettingsKeys {
     val CHINESE_TYPE = stringPreferencesKey("chinese_type")
     val TRANSLATION_LANGUAGE = stringPreferencesKey("translation_language")
     val HISTORY = stringPreferencesKey("history")
+    val REVIEW_LAUNCH_COUNT = intPreferencesKey("review_launch_count")
+    val REVIEW_PROMPT_DISMISSED = booleanPreferencesKey("review_prompt_dismissed")
+    val REVIEW_ATTEMPTS = intPreferencesKey("review_attempts")
 }
 
 class AppSettingsRepository(private val context: Context) {
@@ -33,6 +38,18 @@ class AppSettingsRepository(private val context: Context) {
 
     val history = context.dataStore.data.map { prefs ->
         HistorySerializer.fromJson(prefs[AppSettingsKeys.HISTORY] ?: "")
+    }
+
+    val reviewLaunchCount = context.dataStore.data.map { prefs ->
+        prefs[AppSettingsKeys.REVIEW_LAUNCH_COUNT] ?: 0
+    }
+
+    val reviewPromptDismissed = context.dataStore.data.map { prefs ->
+        prefs[AppSettingsKeys.REVIEW_PROMPT_DISMISSED] ?: false
+    }
+
+    val reviewAttempts = context.dataStore.data.map { prefs ->
+        prefs[AppSettingsKeys.REVIEW_ATTEMPTS] ?: 0
     }
 
     suspend fun setChineseType(value: String) {
@@ -76,6 +93,37 @@ class AppSettingsRepository(private val context: Context) {
         context.dataStore.edit { prefs ->
             prefs[AppSettingsKeys.HISTORY] =
                 HistorySerializer.toJson(HistoryStore.clear())
+        }
+    }
+
+    /** Increment the cold-launch counter, capped per policy. Call once per cold start. */
+    suspend fun registerLaunch() {
+        context.dataStore.edit { prefs ->
+            val current = prefs[AppSettingsKeys.REVIEW_LAUNCH_COUNT] ?: 0
+            prefs[AppSettingsKeys.REVIEW_LAUNCH_COUNT] =
+                ReviewPromptPolicy.nextLaunchCount(current)
+        }
+    }
+
+    /** Mark the review prompt handled so it never fires again. */
+    suspend fun dismissReviewForever() {
+        context.dataStore.edit { it[AppSettingsKeys.REVIEW_PROMPT_DISMISSED] = true }
+    }
+
+    /** Record a native-flow attempt that did not visibly show; retried later. */
+    suspend fun incrementReviewAttempts() {
+        context.dataStore.edit { prefs ->
+            prefs[AppSettingsKeys.REVIEW_ATTEMPTS] =
+                (prefs[AppSettingsKeys.REVIEW_ATTEMPTS] ?: 0) + 1
+        }
+    }
+
+    /** Debug aid: clear dismissed flag and launch count so the prompt can re-trigger. */
+    suspend fun resetReviewPrompt() {
+        context.dataStore.edit { prefs ->
+            prefs[AppSettingsKeys.REVIEW_LAUNCH_COUNT] = 0
+            prefs[AppSettingsKeys.REVIEW_PROMPT_DISMISSED] = false
+            prefs[AppSettingsKeys.REVIEW_ATTEMPTS] = 0
         }
     }
 }

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/services/ReviewPromptPolicy.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/services/ReviewPromptPolicy.kt
@@ -1,0 +1,40 @@
+package dev.veeso.biangbianghanzi.services
+
+/** Pure, side-effect-free decision logic for the "rate the app" prompt. */
+object ReviewPromptPolicy {
+    /**
+     * Minimum cold launches before the prompt is eligible. Set to the cap (5)
+     * because the Play In-App Review flow is one-shot with no opt-out or
+     * re-prompt: spend the single chance on an engaged user.
+     */
+    const val LAUNCH_THRESHOLD = 5
+
+    /** Counter cap to avoid unbounded writes. */
+    const val LAUNCH_CAP = 5
+
+    /**
+     * Max times the native flow may be attempted before giving up. The Play
+     * In-App Review API never reports whether the card was actually shown
+     * (quota / non-Play build → silent no-op), so we retry across launches and
+     * stop after this many attempts to avoid retrying forever.
+     */
+    const val MAX_ATTEMPTS = 5
+
+    /**
+     * Below this elapsed time (ms) for launchReviewFlow, assume the card was
+     * NOT shown: a real card requires user interaction and suspends far longer;
+     * a quota/non-Play no-op completes near-instantly.
+     */
+    const val SHOWN_MIN_ELAPSED_MS = 800L
+
+    fun nextLaunchCount(current: Int): Int = minOf(current + 1, LAUNCH_CAP)
+
+    fun shouldShow(launchCount: Int, dismissed: Boolean): Boolean =
+        !dismissed && launchCount >= LAUNCH_THRESHOLD
+
+    /** True once attempts exhausted; give up so the flow stops retrying. */
+    fun reachedAttemptCap(attempts: Int): Boolean = attempts >= MAX_ATTEMPTS
+
+    /** Heuristic: a plausibly-shown card suspends the flow at least this long. */
+    fun looksShown(elapsedMs: Long): Boolean = elapsedMs >= SHOWN_MIN_ELAPSED_MS
+}

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/MainScreen.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/MainScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import dev.veeso.biangbianghanzi.ui.components.ReviewPrompt
 import dev.veeso.biangbianghanzi.ui.screens.CameraModeView
 import dev.veeso.biangbianghanzi.ui.screens.HistoryModeView
 import dev.veeso.biangbianghanzi.ui.screens.SettingsModeView
@@ -57,6 +58,7 @@ fun MainScreen() {
                 Tab.History -> HistoryModeView()
                 Tab.Settings -> SettingsModeView()
             }
+            ReviewPrompt()
         }
     }
 }

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/components/ReviewPrompt.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/components/ReviewPrompt.kt
@@ -1,0 +1,98 @@
+package dev.veeso.biangbianghanzi.ui.components
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.util.Log
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import com.google.android.play.core.review.ReviewManagerFactory
+import dev.veeso.biangbianghanzi.services.AppSettingsRepository
+import dev.veeso.biangbianghanzi.services.ReviewPromptPolicy
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.tasks.await
+
+private const val TAG = "ReviewPrompt"
+
+private fun Context.findActivity(): Activity? {
+    var ctx = this
+    while (ctx is ContextWrapper) {
+        if (ctx is Activity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
+}
+
+/**
+ * Runs the Play In-App Review flow once. Returns true only if the flow
+ * *plausibly* displayed the card, inferred from how long `launchReviewFlow`
+ * suspended: Google never reveals whether the card was shown, but a real card
+ * requires user interaction (long), while a quota / non-Play no-op completes
+ * near-instantly. Logs every stage for diagnosis.
+ */
+suspend fun launchInAppReview(context: Context): Boolean {
+    val activity = context.findActivity()
+    if (activity == null) {
+        Log.w(TAG, "no Activity from context; aborting")
+        return false
+    }
+    return try {
+        val manager = ReviewManagerFactory.create(context)
+        Log.d(TAG, "requesting review flow")
+        val info = manager.requestReviewFlow().await()
+        Log.d(TAG, "requestReviewFlow ok; launching")
+        val start = System.currentTimeMillis()
+        manager.launchReviewFlow(activity, info).await()
+        val elapsed = System.currentTimeMillis() - start
+        val shown = ReviewPromptPolicy.looksShown(elapsed)
+        Log.d(TAG, "launchReviewFlow completed in ${elapsed}ms looksShown=$shown")
+        shown
+    } catch (e: Exception) {
+        Log.e(TAG, "review flow failed", e)
+        false
+    }
+}
+
+/**
+ * Side-effect-only. Once the user has launched the app enough times, request
+ * the Play In-App Review flow at a natural pause (app open). The API never
+ * confirms the card was shown, so: if it plausibly showed, mark handled; if it
+ * no-op'd (quota / non-Play build), keep eligible and retry on later launches,
+ * giving up only after MAX_ATTEMPTS so it can't retry forever.
+ */
+@Composable
+fun ReviewPrompt() {
+    val context = LocalContext.current
+    val repo = remember { AppSettingsRepository(context.applicationContext) }
+
+    val launchCount by repo.reviewLaunchCount.collectAsState(initial = 0)
+    val dismissed by repo.reviewPromptDismissed.collectAsState(initial = true)
+
+    LaunchedEffect(launchCount, dismissed) {
+        val show = ReviewPromptPolicy.shouldShow(launchCount, dismissed)
+        Log.d(TAG, "state launchCount=$launchCount dismissed=$dismissed shouldShow=$show")
+        if (!show) return@LaunchedEffect
+
+        val shown = launchInAppReview(context)
+        if (shown) {
+            repo.dismissReviewForever()
+            Log.d(TAG, "card plausibly shown; marked dismissed")
+            return@LaunchedEffect
+        }
+
+        // Read persisted attempts fresh (not keyed → no same-session retry loop).
+        val attemptsBefore = repo.reviewAttempts.first()
+        repo.incrementReviewAttempts()
+        val attemptsAfter = attemptsBefore + 1
+        if (ReviewPromptPolicy.reachedAttemptCap(attemptsAfter)) {
+            repo.dismissReviewForever()
+            Log.d(TAG, "attempt cap reached ($attemptsAfter); giving up, marked dismissed")
+        } else {
+            Log.d(TAG, "no-op (attempt $attemptsAfter); staying eligible, will retry")
+        }
+    }
+}

--- a/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/screens/SettingsModeView.kt
+++ b/android/app/src/main/java/dev/veeso/biangbianghanzi/ui/screens/SettingsModeView.kt
@@ -35,11 +35,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.core.os.ConfigurationCompat
+import dev.veeso.biangbianghanzi.BuildConfig
 import dev.veeso.biangbianghanzi.services.AppSettingsRepository
 import dev.veeso.biangbianghanzi.services.CANTONESE
 import dev.veeso.biangbianghanzi.services.SIMPLIFIED_CHINESE
+import dev.veeso.biangbianghanzi.services.ReviewPromptPolicy
 import dev.veeso.biangbianghanzi.services.TRADITIONAL_CHINESE
 import dev.veeso.biangbianghanzi.ui.AppDesign
+import dev.veeso.biangbianghanzi.ui.components.launchInAppReview
 import kotlinx.coroutines.launch
 import java.util.Locale
 
@@ -59,6 +62,10 @@ fun SettingsModeView(repo: AppSettingsRepository = AppSettingsRepository(LocalCo
             .distinctBy { it.displayLanguage }
             .sortedBy { it.displayLanguage }
     }
+
+    val reviewLaunchCount by repo.reviewLaunchCount.collectAsState(initial = 0)
+    val reviewDismissed by repo.reviewPromptDismissed.collectAsState(initial = false)
+    val reviewAttempts by repo.reviewAttempts.collectAsState(initial = 0)
 
     val chineseType by repo.chineseType.collectAsState(initial = SIMPLIFIED_CHINESE)
     val translationLanguage by repo.translationLanguage.collectAsState(
@@ -142,6 +149,26 @@ fun SettingsModeView(repo: AppSettingsRepository = AppSettingsRepository(LocalCo
                     }
                     Button(onClick = { sendBugEmail(context) }) {
                         Text("Send Email")
+                    }
+                }
+            }
+
+            if (BuildConfig.DEBUG) {
+                SettingsSection(title = "Debug") {
+                    Text(
+                        "review launchCount=$reviewLaunchCount dismissed=$reviewDismissed " +
+                            "attempts=$reviewAttempts/${ReviewPromptPolicy.MAX_ATTEMPTS} " +
+                            "(fires at ${ReviewPromptPolicy.LAUNCH_THRESHOLD})",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Button(onClick = { scope.launch { repo.resetReviewPrompt() } }) {
+                            Text("Reset")
+                        }
+                        Button(onClick = { scope.launch { launchInAppReview(context) } }) {
+                            Text("Force review now")
+                        }
                     }
                 }
             }

--- a/android/app/src/test/java/dev/veeso/biangbianghanzi/ReviewPromptPolicyTest.kt
+++ b/android/app/src/test/java/dev/veeso/biangbianghanzi/ReviewPromptPolicyTest.kt
@@ -1,0 +1,41 @@
+package dev.veeso.biangbianghanzi
+
+import dev.veeso.biangbianghanzi.services.ReviewPromptPolicy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReviewPromptPolicyTest {
+    @Test
+    fun nextLaunchCountCapsAtFive() {
+        assertEquals(1, ReviewPromptPolicy.nextLaunchCount(0))
+        assertEquals(5, ReviewPromptPolicy.nextLaunchCount(4))
+        assertEquals(5, ReviewPromptPolicy.nextLaunchCount(5))
+        assertEquals(5, ReviewPromptPolicy.nextLaunchCount(99))
+    }
+
+    @Test
+    fun shouldShowOnlyWhenThresholdReachedAndNotDismissed() {
+        assertTrue(ReviewPromptPolicy.shouldShow(launchCount = 5, dismissed = false))
+        assertFalse(ReviewPromptPolicy.shouldShow(launchCount = 4, dismissed = false))
+        assertFalse(ReviewPromptPolicy.shouldShow(launchCount = 3, dismissed = false))
+        assertFalse(ReviewPromptPolicy.shouldShow(launchCount = 5, dismissed = true))
+    }
+
+    @Test
+    fun reachedAttemptCapAtMax() {
+        assertFalse(ReviewPromptPolicy.reachedAttemptCap(0))
+        assertFalse(ReviewPromptPolicy.reachedAttemptCap(ReviewPromptPolicy.MAX_ATTEMPTS - 1))
+        assertTrue(ReviewPromptPolicy.reachedAttemptCap(ReviewPromptPolicy.MAX_ATTEMPTS))
+        assertTrue(ReviewPromptPolicy.reachedAttemptCap(ReviewPromptPolicy.MAX_ATTEMPTS + 3))
+    }
+
+    @Test
+    fun looksShownOnlyWhenFlowSuspendedLongEnough() {
+        assertFalse(ReviewPromptPolicy.looksShown(0L))
+        assertFalse(ReviewPromptPolicy.looksShown(ReviewPromptPolicy.SHOWN_MIN_ELAPSED_MS - 1))
+        assertTrue(ReviewPromptPolicy.looksShown(ReviewPromptPolicy.SHOWN_MIN_ELAPSED_MS))
+        assertTrue(ReviewPromptPolicy.looksShown(5_000L))
+    }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ activityCompose = "1.13.0"
 composeBom = "2026.05.00"
 material3 = "1.4.0"
 materialIconsExtended = "1.7.8"
+playReview = "2.0.2"
 pinyin4j = "2.5.1"
 textRecognitionChinese = "16.0.1"
 translate = "17.0.3"
@@ -45,6 +46,7 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutinesPlayServices" }
 org-json = { module = "org.json:json", version.ref = "orgJson" }
+play-review-ktx = { module = "com.google.android.play:review-ktx", version.ref = "playReview" }
 pinyin4j = { module = "com.belerweb:pinyin4j", version.ref = "pinyin4j" }
 text-recognition-chinese = { module = "com.google.mlkit:text-recognition-chinese", version.ref = "textRecognitionChinese" }
 translate = { module = "com.google.mlkit:translate", version.ref = "translate" }

--- a/ios/BiangBiang Hanzi/AppSettings.swift
+++ b/ios/BiangBiang Hanzi/AppSettings.swift
@@ -37,6 +37,14 @@ final class AppSettings {
         }
     }
 
+    var reviewLaunchCount: Int {
+        didSet { userDefaults.set(reviewLaunchCount, forKey: "review_launch_count") }
+    }
+
+    var reviewPromptDismissed: Bool {
+        didSet { userDefaults.set(reviewPromptDismissed, forKey: "review_prompt_dismissed") }
+    }
+
     private let userDefaults: UserDefaults
 
     init(
@@ -57,6 +65,8 @@ final class AppSettings {
         } else {
             history = []
         }
+        reviewLaunchCount = userDefaults.integer(forKey: "review_launch_count")
+        reviewPromptDismissed = userDefaults.bool(forKey: "review_prompt_dismissed")
     }
 
     func addHistory(original: String, transliteration: String, variant: HistoryVariant) {
@@ -70,5 +80,20 @@ final class AppSettings {
 
     func clearHistory() {
         history = HistoryStore.clear()
+    }
+
+    /// Increment the cold-launch counter, capped per policy. Call once per process launch.
+    func registerLaunch() {
+        reviewLaunchCount = ReviewPromptPolicy.nextLaunchCount(reviewLaunchCount)
+    }
+
+    /// "Not now": reset the counter, keep prompting after 3 more launches.
+    func notNow() {
+        reviewLaunchCount = 0
+    }
+
+    /// "Rate now" / "Don't ask again": never show the prompt again.
+    func dismissForever() {
+        reviewPromptDismissed = true
     }
 }

--- a/ios/BiangBiang Hanzi/BiangBiang_HanziApp.swift
+++ b/ios/BiangBiang Hanzi/BiangBiang_HanziApp.swift
@@ -12,6 +12,10 @@ struct BiangBiang_HanziApp: App {
     @State private var settings = AppSettings()
     @State private var audio = AudioPlayerService()
 
+    init() {
+        settings.registerLaunch()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/ios/BiangBiang Hanzi/ContentView.swift
+++ b/ios/BiangBiang Hanzi/ContentView.swift
@@ -15,7 +15,15 @@ struct ContentView: View {
         case history
     }
 
+    static let appStoreID = "6754869174"
+    static let writeReviewURL = URL(
+        string: "https://apps.apple.com/app/id6754869174?action=write-review"
+    )!
+
+    @Environment(AppSettings.self) private var settings
+    @Environment(\.openURL) private var openURL
     @State private var selection: AppTab = .text
+    @State private var showReviewPrompt = false
 
     var body: some View {
         TabView(selection: $selection) {
@@ -31,6 +39,28 @@ struct ContentView: View {
             Tab("Settings", systemImage: "gear", value: AppTab.settings) {
                 SettingsView()
             }
+        }
+        .task {
+            showReviewPrompt = ReviewPromptPolicy.shouldShow(
+                launchCount: settings.reviewLaunchCount,
+                dismissed: settings.reviewPromptDismissed
+            )
+        }
+        .alert("Enjoying BiangBiang Hanzi?", isPresented: $showReviewPrompt) {
+            Button("Rate now") {
+                settings.dismissForever()
+                openURL(Self.writeReviewURL)
+            }
+            Button("Not now", role: .cancel) {
+                settings.notNow()
+            }
+            Button("Don't ask again", role: .destructive) {
+                settings.dismissForever()
+            }
+        } message: {
+            Text(
+                "If BiangBiang Hanzi has been helpful, a quick rating on the App Store really helps. It only takes a moment."
+            )
         }
     }
 }

--- a/ios/BiangBiang Hanzi/Services/ReviewPromptPolicy.swift
+++ b/ios/BiangBiang Hanzi/Services/ReviewPromptPolicy.swift
@@ -1,0 +1,22 @@
+//
+//  ReviewPromptPolicy.swift
+//  BiangBiang Hanzi
+//
+
+import Foundation
+
+/// Pure, side-effect-free decision logic for the "rate the app" prompt.
+enum ReviewPromptPolicy {
+    /// Minimum cold launches before the prompt is eligible to show.
+    static let launchThreshold = 3
+    /// Counter cap to avoid unbounded writes.
+    static let launchCap = 5
+
+    static func nextLaunchCount(_ current: Int) -> Int {
+        min(current + 1, launchCap)
+    }
+
+    static func shouldShow(launchCount: Int, dismissed: Bool) -> Bool {
+        !dismissed && launchCount >= launchThreshold
+    }
+}

--- a/ios/BiangBiang Hanzi/Views/SettingsView.swift
+++ b/ios/BiangBiang Hanzi/Views/SettingsView.swift
@@ -11,6 +11,10 @@ struct SettingsView: View {
     @Environment(AppSettings.self) private var settings
     @Environment(\.openURL) private var openURL
 
+    #if DEBUG
+        @State private var showResetToast = false
+    #endif
+
     private static let availableLanguages: [(id: String, name: String)] =
         Locale.availableIdentifiers.map { id in
             (
@@ -75,9 +79,37 @@ struct SettingsView: View {
                 } header: {
                     Label("Report a bug", systemImage: "ladybug")
                 }
+
+                #if DEBUG
+                    Section {
+                        Button("Reset review prompt", systemImage: "arrow.counterclockwise") {
+                            settings.reviewPromptDismissed = false
+                            settings.reviewLaunchCount = 0
+                            showResetToast = true
+                        }
+                    } header: {
+                        Label("Debug", systemImage: "hammer")
+                    } footer: {
+                        Text("Clears dismissed flag and launch count. Restart the app to re-trigger after 3 launches.")
+                    }
+                #endif
             }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
+            #if DEBUG
+                .overlay(alignment: .bottom) {
+                    if showResetToast {
+                        CopyToast(message: "Review prompt reset")
+                            .padding(.bottom, 24)
+                            .transition(.move(edge: .bottom).combined(with: .opacity))
+                            .task {
+                                try? await Task.sleep(for: .seconds(2))
+                                showResetToast = false
+                            }
+                    }
+                }
+                .animation(.easeInOut, value: showResetToast)
+            #endif
         }
     }
 

--- a/ios/BiangBiang HanziTests/AppSettingsReviewTests.swift
+++ b/ios/BiangBiang HanziTests/AppSettingsReviewTests.swift
@@ -1,0 +1,53 @@
+@testable import BiangBiang_Hanzi
+import Foundation
+import Testing
+
+@MainActor
+struct AppSettingsReviewTests {
+    private func makeDefaults() -> UserDefaults {
+        let suite = "review-test-\(UUID().uuidString)"
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        return d
+    }
+
+    @Test func defaultsAreZeroAndNotDismissed() {
+        let s = AppSettings(userDefaults: makeDefaults())
+        #expect(s.reviewLaunchCount == 0)
+        #expect(s.reviewPromptDismissed == false)
+    }
+
+    @Test func registerLaunchIncrementsAndCapsAtFive() {
+        let s = AppSettings(userDefaults: makeDefaults())
+        for _ in 0 ..< 7 {
+            s.registerLaunch()
+        }
+        #expect(s.reviewLaunchCount == 5)
+    }
+
+    @Test func registerLaunchPersists() {
+        let d = makeDefaults()
+        let a = AppSettings(userDefaults: d)
+        a.registerLaunch()
+        a.registerLaunch()
+        let b = AppSettings(userDefaults: d)
+        #expect(b.reviewLaunchCount == 2)
+    }
+
+    @Test func notNowResetsCountKeepsDismissedFalse() {
+        let s = AppSettings(userDefaults: makeDefaults())
+        s.registerLaunch(); s.registerLaunch(); s.registerLaunch()
+        s.notNow()
+        #expect(s.reviewLaunchCount == 0)
+        #expect(s.reviewPromptDismissed == false)
+    }
+
+    @Test func dismissForeverPersists() {
+        let d = makeDefaults()
+        let a = AppSettings(userDefaults: d)
+        a.dismissForever()
+        #expect(a.reviewPromptDismissed == true)
+        let b = AppSettings(userDefaults: d)
+        #expect(b.reviewPromptDismissed == true)
+    }
+}

--- a/ios/BiangBiang HanziTests/Services/ReviewPromptPolicyTests.swift
+++ b/ios/BiangBiang HanziTests/Services/ReviewPromptPolicyTests.swift
@@ -1,0 +1,18 @@
+@testable import BiangBiang_Hanzi
+import Testing
+
+struct ReviewPromptPolicyTests {
+    @Test func incrementCapsAtFive() {
+        #expect(ReviewPromptPolicy.nextLaunchCount(0) == 1)
+        #expect(ReviewPromptPolicy.nextLaunchCount(4) == 5)
+        #expect(ReviewPromptPolicy.nextLaunchCount(5) == 5)
+        #expect(ReviewPromptPolicy.nextLaunchCount(99) == 5)
+    }
+
+    @Test func showsOnlyWhenCountReachedAndNotDismissed() {
+        #expect(ReviewPromptPolicy.shouldShow(launchCount: 3, dismissed: false) == true)
+        #expect(ReviewPromptPolicy.shouldShow(launchCount: 5, dismissed: false) == true)
+        #expect(ReviewPromptPolicy.shouldShow(launchCount: 2, dismissed: false) == false)
+        #expect(ReviewPromptPolicy.shouldShow(launchCount: 4, dismissed: true) == false)
+    }
+}


### PR DESCRIPTION
Closes #20

## Summary

Adds a "rate the app" prompt gated on cold-launch count, implemented separately per platform per their store guidance.

### iOS — custom dialog + App Store deep link
- Custom 3-button SwiftUI `.alert` from `ContentView`, shown when `reviewLaunchCount >= 3` and not dismissed.
- **Rate now** opens the App Store write-review URL via `openURL` (reliable, unlike `requestReview` which is invisible/rate-limited in dev) + permanent dismiss.
- **Not now** resets the counter (re-prompts after 3 more launches). **Don't ask again** permanent dismiss.
- `AppSettings` persists `reviewLaunchCount` (cap 5) / `reviewPromptDismissed`; launch registered once at app init.
- DEBUG-only Settings reset row with confirmation toast.

### Android — Google-pure native In-App Review
- No custom UI. After **5** cold launches the Play In-App Review flow is requested once at app open.
- The API never reports whether the card displayed (quota / non-Play build = silent no-op), so `launchReviewFlow` elapsed time is a heuristic: `< 800ms` ⇒ not shown → stay eligible, retry on later launches; give up after `MAX_ATTEMPTS = 5`.
- Threshold is 5 (vs iOS 3) because the native flow is one-shot with no opt-out/re-prompt — spend the single chance on an engaged user.
- DataStore keys `review_launch_count` / `review_prompt_dismissed` / `review_attempts`; launch registered on true cold start.
- DEBUG Settings section: live state readout, Reset, Force review.

## Tests
- iOS: `ReviewPromptPolicyTests`, `AppSettingsReviewTests` (Swift Testing).
- Android: `ReviewPromptPolicyTest` (JUnit) — `shouldShow`, `nextLaunchCount` cap, `reachedAttemptCap`, `looksShown`.
- Builds: iOS `xcodebuild` ✅, Android `assembleDebug` + unit tests ✅.

## Notes
- Native review card only renders on a Play track (internal testing / production), quota-limited — unverifiable on local debug installs by Google design. Heuristic prevents burning the one-shot on invisible no-ops.
- On-device verification done by maintainer.